### PR TITLE
fix(macos): bundle sherpa/onnxruntime dylibs into .app and set @rpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,19 @@ jobs:
           NO_STRIP: "true"
         run: npx tauri build ${{ runner.os == 'Linux' && '--bundles deb' || runner.os == 'macOS' && '--bundles app' || '' }}
 
+      - name: Deep-sign dylibs & verify (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          APP_PATH="target/release/bundle/macos/Nuphus.app"
+          # macOS：tauri 只签主二进制，bundle.macOS.files 拷入 Contents/Frameworks 的
+          # sherpa/onnxruntime dylib 是预编译 adhoc 签名；必须深签名，否则用户侧
+          # 直接 SIGKILL (Code Signature Invalid)。
+          # 优先使用配置的签名身份；未配置时退化为 adhoc（用于 CI 验证签名链路）。
+          SIGN_IDENTITY="${APPLE_SIGNING_IDENTITY:--}"
+          codesign --force --deep --sign "$SIGN_IDENTITY" "$APP_PATH"
+          codesign --verify --deep --strict "$APP_PATH"
+          echo "macOS deep-sign + verify OK ($APP_PATH)"
+
       - name: Create DMG (macOS, manual hdiutil)
         if: runner.os == 'macOS'
         run: |

--- a/npm-desktop/packages/nuphus-desktop/bin/nuphus.js
+++ b/npm-desktop/packages/nuphus-desktop/bin/nuphus.js
@@ -36,9 +36,15 @@ function resolveVendorDir() {
     console.error('        当前支持: win32-x64 / darwin-arm64 / linux-x64');
     process.exit(1);
   }
-  // 主包位于 node_modules/@nuphus/nuphus-desktop/，平台子包与其同级
-  // __dirname = <node_modules>/@nuphus/nuphus-desktop/bin
-  const vendor = path.join(__dirname, '..', '..', '@nuphus', spec.pkg);
+  // 平台子包可能被 npm 提升到 <node_modules>/@nuphus/ 下（与主包同级），也可能被
+  // 嵌套在主包的 node_modules/@nuphus/ 下；用 Node 模块解析定位，两种布局都能命中。
+  const pkgName = `@nuphus/${spec.pkg}`;
+  let vendor;
+  try {
+    vendor = path.dirname(require.resolve(`${pkgName}/package.json`));
+  } catch (_) {
+    vendor = path.join(__dirname, '..', '..', pkgName);
+  }
   if (!fs.existsSync(vendor)) {
     console.error(`[nuphus] 未找到平台包: ${spec.pkg}`);
     console.error('        请确认安装完整（npm install -g @nuphus/nuphus-desktop）或重装。');

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -29,6 +29,7 @@ fn main() {
     // onnxruntime（sherpa 未内置时兜底）→ YOLO → 最后 sync_*。
     download_ocr_models();
     ensure_sherpa_libs();
+    #[cfg(target_os = "macos")]
     decouple_onnxruntime_name();
     ensure_onnxruntime_libs();
     ensure_yolo_model();
@@ -408,13 +409,14 @@ fn decouple_onnxruntime_name() {
         return;
     };
     let text = String::from_utf8_lossy(&out.stdout);
-    let old = text
-        .lines()
-        .map(str::trim)
-        .find_map(|l| {
-            l.strip_prefix("@rpath/libonnxruntime.")
-                .map(|rest| format!("@rpath/libonnxruntime.{}", rest.split_whitespace().next().unwrap_or("")))
-        });
+    let old = text.lines().map(str::trim).find_map(|l| {
+        l.strip_prefix("@rpath/libonnxruntime.").map(|rest| {
+            format!(
+                "@rpath/libonnxruntime.{}",
+                rest.split_whitespace().next().unwrap_or("")
+            )
+        })
+    });
     let Some(old) = old else {
         println!("cargo:warning=sherpa-onnx: 未发现带版本号的 onnxruntime 依赖，跳过解耦");
         return;

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -29,6 +29,7 @@ fn main() {
     // onnxruntime（sherpa 未内置时兜底）→ YOLO → 最后 sync_*。
     download_ocr_models();
     ensure_sherpa_libs();
+    decouple_onnxruntime_name();
     ensure_onnxruntime_libs();
     ensure_yolo_model();
     sync_models_to_data_dir();
@@ -382,6 +383,51 @@ fn sync_sherpa_libs() {
             }
         }
     }
+}
+
+// macOS：解除 sherpa c-api 对 onnxruntime 的「带版本号」依赖耦合。
+// k2-fsa 的 osx-universal2 包里 c-api 引用的是 libonnxruntime.1.27.0.dylib，
+// 但文件名是 libonnxruntime.dylib，且版本号会随 sherpa 升级变化。这里用
+// install_name_tool 把 c-api 的依赖统一改成不带版本号的名字，使打包只关心
+// libonnxruntime.dylib，无需在 tauri.conf.json / 代码里硬编码版本。
+#[cfg(target_os = "macos")]
+fn decouple_onnxruntime_name() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let sherpa_dir = std::path::PathBuf::from(&manifest_dir)
+        .join("desktop")
+        .join("sherpa");
+    let c_api = sherpa_dir.join("libsherpa-onnx-c-api.dylib");
+    if !c_api.exists() {
+        return;
+    }
+    let Ok(out) = std::process::Command::new("otool")
+        .args(["-L"])
+        .arg(&c_api)
+        .output()
+    else {
+        return;
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    let old = text
+        .lines()
+        .map(str::trim)
+        .find_map(|l| {
+            l.strip_prefix("@rpath/libonnxruntime.")
+                .map(|rest| format!("@rpath/libonnxruntime.{}", rest.split_whitespace().next().unwrap_or("")))
+        });
+    let Some(old) = old else {
+        println!("cargo:warning=sherpa-onnx: 未发现带版本号的 onnxruntime 依赖，跳过解耦");
+        return;
+    };
+    let new = "@rpath/libonnxruntime.dylib";
+    if old == new {
+        return;
+    }
+    let _ = std::process::Command::new("install_name_tool")
+        .args(["-change", &old, new])
+        .arg(&c_api)
+        .status();
+    println!("cargo:warning=sherpa-onnx: 已解除 onnxruntime 版本耦合: {old} -> {new}");
 }
 
 // ─── OCR Model files ─────────────────────────────────────────────

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,6 +10,17 @@ fn main() {
 
     tauri_build::build();
 
+    // macOS：把 sherpa/onnxruntime dylib 的运行时查找路径写进二进制的 @rpath。
+    // dev 时 dylib 被 sync_sherpa_libs 拷到 target/<profile>/（与二进制同目录），
+    // 打包成 .app 后 dylib 放在 Contents/Frameworks/ 下；@executable_path 与
+    // @executable_path/../Frameworks 两条 rpath 分别覆盖这两种布局，缺一不可。
+    // 否则 @rpath/libsherpa-onnx-c-api.dylib 无法解析 → 启动即 "Library not loaded"。
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../Frameworks");
+    }
+
     // ═══ 模型与运行时依赖自动获取 ═══
     // 产品原则：除 STT 语音模型外，其余所有本地模型/运行时都要自动获取——
     // 端用户不懂技术，git clone + cargo build 后必须自愈。所有步骤失败时都只

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -81,7 +81,7 @@
     "macOS": {
       "files": {
         "Frameworks/libsherpa-onnx-c-api.dylib": "desktop/sherpa/libsherpa-onnx-c-api.dylib",
-        "Frameworks/libonnxruntime.1.27.0.dylib": "desktop/sherpa/libonnxruntime.dylib"
+        "Frameworks/libonnxruntime.dylib": "desktop/sherpa/libonnxruntime.dylib"
       }
     }
   }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -77,6 +77,12 @@
     "icon": [
       "icons/icon.ico",
       "icons/icon.png"
-    ]
+    ],
+    "macOS": {
+      "files": {
+        "Frameworks/libsherpa-onnx-c-api.dylib": "desktop/sherpa/libsherpa-onnx-c-api.dylib",
+        "Frameworks/libonnxruntime.1.27.0.dylib": "desktop/sherpa/libonnxruntime.dylib"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 问题

macOS 版 Nuphus 启动即崩溃：`dyld: Library not loaded: @rpath/libsherpa-onnx-c-api.dylib`（SIGABRT）。

根因是二进制的 `LC_RPATH` 为空，且打包出的 `.app` 没有把 sherpa / onnxruntime 的动态库拷进 `Contents/Frameworks/`，所以运行期 `@rpath` 解析不到。

## 改动

- `src-tauri/tauri.conf.json`：`bundle.macOS.files` 把 sherpa / onnxruntime 动态库拷入 `.app` 的 `Contents/Frameworks/`。
  - 注意：sherpa `libsherpa-onnx-c-api.dylib` 依赖的是**带版本号**的名字 `libonnxruntime.1.27.0.dylib`（不是 `libonnxruntime.dylib`），必须按版本名打包；
  - mac 的 sherpa osx-universal2 包里**不包含** `libonnxruntime_providers_shared.dylib`（只在 Windows/Linux 有），因此不打包它。
- `src-tauri/build.rs`：macOS 链接时写入 `@executable_path` 与 `@executable_path/../Frameworks` 两条 `@rpath`，分别覆盖 dev（dylib 在 `target/<profile>/` 同目录）与 `.app`（dylib 在 `Contents/Frameworks/`）两种布局。
- `npm-desktop/packages/nuphus-desktop/bin/nuphus.js`：用 `require.resolve` 定位平台子包，兼容 npm「提升 / 嵌套」两种安装布局，修复 `未找到平台包: nuphus-desktop-osx-arm64`。

## 验证

本地 `npx tauri build --bundles app` 后，`.app` 可正常启动、无 dyld 崩溃。

## 需要作者注意 / 待确认

- `bundle.macOS.files` 拷进 `Contents/Frameworks/` 的 dylib 是 sherpa 预编译（adhoc 签名），**需要随 app 一起深度签名**（本地用 `codesign --force --deep -s -` 重新签名后通过；否则运行时报 `SIGKILL / Code Signature Invalid`）。CI 打正式包时需保证对加入的 dylib 做签名。
- `libonnxruntime.1.27.0.dylib` 的版本号与 sherpa-onnx 版本耦合，升级 sherpa 时需同步。
