### PR TITLE
fix(ui): 回复完成后「回顾过程」指示器的关闭(X)应真正隐藏

### DIFF
--- a/frontend/src/main-window/App.tsx
+++ b/frontend/src/main-window/App.tsx
@@ -327,6 +327,7 @@ export default function App() {
               step={s.dismissThinking ? '' : s.thinkingStep}
               isThinking={s.isProcessing}
               completed={s.completed}
+              dismissed={s.dismissThinking}
               phase={s.execPhase}
               timeline={s.timeline}
               mood={s.mood}

--- a/frontend/src/main-window/layout/ThinkingIndicator.tsx
+++ b/frontend/src/main-window/layout/ThinkingIndicator.tsx
@@ -8,6 +8,7 @@ interface ThinkingIndicatorProps {
   step: string
   isThinking: boolean
   completed?: boolean
+  dismissed?: boolean
   phase?: 'understanding' | 'executing' | 'recording' | 'workflow' | 'retrying' | ''
   timeline?: TimelineEntry[]
   mood?: MoodState
@@ -36,6 +37,7 @@ export function ThinkingIndicator({
   step,
   isThinking,
   completed,
+  dismissed,
   phase,
   timeline,
   mood,
@@ -44,6 +46,8 @@ export function ThinkingIndicator({
   onClose,
 }: ThinkingIndicatorProps) {
   const { t } = useLanguage()
+  // 已点击「关闭」：无论是否 completed / isThinking，整条指示器都应隐藏。
+  if (dismissed) return null
   if (!completed && !isThinking && !step) return null
 
   const phaseColor = completed ? '#22c55e' : phase ? PHASE_COLORS[phase] : '#3b82f6'


### PR DESCRIPTION
## 问题

回复完成后，界面下方出现「回复完成，点击回顾过程」指示器（`ThinkingIndicator`）。点它右上角的关闭(X) 没有反应。

根因：点击 X 调用 `onClose` → `setDismissThinking(true)`，但 `dismissThinking` 只是把指示器的 `step` 文字清空；而指示器在 `completed` 为 true 时始终显示，因此「关闭」实际上什么也不做。

## 改动

- `frontend/src/main-window/layout/ThinkingIndicator.tsx`：新增 `dismissed?: boolean` prop，`dismissed` 为 true 时整条指示器直接返回 `null`（不再被 `completed` / `isThinking` 卡住）。
- `frontend/src/main-window/App.tsx`：把 `s.dismissThinking` 作为 `dismissed` 传入。

`dismissThinking` 会在下一轮执行开始时由 `useEvents` 的 `setDismissThinking(false)` 重置，因此关闭后随下一条回复完成会重新显示。

## 验证

`completed` 状态下点指示器右上角 X 可真正隐藏；下一轮回复完成时重新出现。
