### PR TITLE
fix(mobile): sync new chat across devices

### DIFF
--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -581,6 +581,7 @@ export type NuphusEvent =
       confidence: number
     }
   | { type: 'session_info'; session_id: string; model: string; timestamp: number }
+  | { type: 'session_changed'; session_id: string; source: 'desktop' | 'mobile' }
   | { type: 'mode_changed'; mode: string }
   | {
       type: 'token_usage'

--- a/frontend/src/hooks/useEvents.ts
+++ b/frontend/src/hooks/useEvents.ts
@@ -121,6 +121,7 @@ export interface EventHandlers {
 
   // Callbacks
   addMessage: (msg: ChatMessage) => void
+  reloadChatFromBackend: () => Promise<void>
   transitionTask?: (taskId: number, status: TaskStatus) => void
 }
 
@@ -219,6 +220,12 @@ export function useEvents(h: EventHandlers) {
         case 'session_info':
           h.setModelName(event.model)
           if (event.session_id) h.setSessionId(event.session_id)
+          break
+        case 'session_changed':
+          // 后端已完成权威会话切换：清空瞬态并从新会话重拉历史。
+          // reloadChatFromBackend 会先同步 resetTransientUI，空历史自然显示欢迎页。
+          h.setSessionId(event.session_id)
+          void h.reloadChatFromBackend()
           break
         case 'understanding_complete':
           if (event.needs_clarification && event.critiques?.length > 0) {
@@ -873,6 +880,7 @@ export function useEvents(h: EventHandlers) {
     h.refs.processingRef,
     h.refs.toolCallCountRef,
     h.addMessage,
+    h.reloadChatFromBackend,
   ])
 
   // ── 移动端安全确认回执：手机端完成确认后，桌面弹窗同步关闭 ──

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -744,6 +744,7 @@ const en: Record<string, string> = {
   'mobile.statusStopped': 'Stopped',
   'mobile.stopFailed': 'Failed to stop, please retry',
   'mobile.newChatStarted': 'New chat started',
+  'mobile.newChatFailed': 'Failed to start a new chat. Please try again.',
   'mobile.dualTitle': 'Dual status',
   'mobile.desktopLabel': 'Desktop',
   'mobile.phoneLabel': 'Phone',

--- a/frontend/src/locales/zh.ts
+++ b/frontend/src/locales/zh.ts
@@ -719,6 +719,7 @@ const zh: Record<string, string> = {
   'mobile.statusStopped': '已停止',
   'mobile.stopFailed': '终止失败，请重试',
   'mobile.newChatStarted': '已开始新会话',
+  'mobile.newChatFailed': '新建会话失败，请稍后重试',
   'mobile.dualTitle': '双端状态',
   'mobile.desktopLabel': '桌面端',
   'mobile.phoneLabel': '手机端',

--- a/frontend/src/mobile/App.tsx
+++ b/frontend/src/mobile/App.tsx
@@ -17,6 +17,7 @@ import {
   wfResume,
   wfStop,
   stopExecution,
+  startNewChat,
   setApiBase,
   getApiBase,
   AuthError,
@@ -780,9 +781,23 @@ export default function App() {
             .catch(() => showToast(t('mobile.stopFailed')))
         }}
         onNewChat={() => {
-          // 新会话：清空前端消息（历史仍在后端，刷新可恢复）
-          dispatch({ type: 'new_chat' })
-          showToast(t('mobile.newChatStarted'))
+          // 以后端会话创建成功为准；session_changed 同时让电脑和其它手机清空视图。
+          if (!token) return
+          void startNewChat(token)
+            .then(() => {
+              // WS 事件可能因瞬时断线漏收，本端用 HTTP 成功响应再兜底清一次（幂等）。
+              dispatch({ type: 'new_chat' })
+              showToast(t('mobile.newChatStarted'))
+            })
+            .catch(e => {
+              if (e instanceof AuthError) {
+                clearToken()
+                setAuthInvalid(true)
+                setPhase('guide')
+                return
+              }
+              showToast(t('mobile.newChatFailed'))
+            })
         }}
         onDisconnect={() => {
           // 断开连接：清除 token + WS，回到配对页

--- a/frontend/src/mobile/api.ts
+++ b/frontend/src/mobile/api.ts
@@ -1,5 +1,5 @@
 /**
- * 移动端 REST API：/history 与 /message
+ * 移动端 REST API：会话、历史与消息入口（/new-chat、/history、/message）
  * 鉴权统一走 X-Mobile-Token Header（WS 才用 query）。
  */
 import type { TraceItem } from './store'
@@ -145,6 +145,32 @@ export async function fetchHistory(token: string): Promise<HistoryMessage[]> {
   )
   if (!res.ok) throw new Error(`history failed: ${res.status}`)
   return (await res.json()) as HistoryMessage[]
+}
+
+export interface NewChatResult {
+  status: 'created'
+  session_id: string
+}
+
+/** 创建真正的后端新会话；成功时后端会广播 session_changed 到桌面和所有手机。 */
+export async function startNewChat(token: string): Promise<NewChatResult> {
+  const res = await checkAuth(
+    await fetchWithTimeout(resolveApi('./new-chat'), {
+      method: 'POST',
+      headers: { 'X-Mobile-Token': token },
+    }),
+  )
+  if (!res.ok) {
+    let error = t('mobile.newChatFailed')
+    try {
+      const body = (await res.json()) as { error?: string }
+      if (body.error) error = body.error
+    } catch {
+      /* 非 JSON 响应，保留本地化默认文案 */
+    }
+    throw new Error(error)
+  }
+  return (await res.json()) as NewChatResult
 }
 
 /** 拉取当前生效的身份显示名（assistant_name / user_label，后端 relation_cache 下发） */

--- a/frontend/src/mobile/components/ChatScreen.tsx
+++ b/frontend/src/mobile/components/ChatScreen.tsx
@@ -62,7 +62,7 @@ interface Props {
   onReloadHistory?: () => void
   /** 终止执行（执行中 NavBar 显示终止按钮，POST /stop 直接终止） */
   onStopExecution?: () => void
-  /** 新会话（Composer + 弹窗触发）：清空前端消息 */
+  /** 新会话：请求后端创建并广播到所有已连接端 */
   onNewChat?: () => void
   /** 断开连接（Composer 设置弹窗触发）：清除 token 回到配对页 */
   onDisconnect?: () => void

--- a/frontend/src/mobile/components/NavBar.tsx
+++ b/frontend/src/mobile/components/NavBar.tsx
@@ -20,7 +20,7 @@ import { t } from '../i18n'
 interface Props {
   wsStatus: WsStatus
   activity: ActivityState
-  /** 新会话（点击 logo 菜单触发）：清空前端消息 */
+  /** 新会话（点击 logo 菜单触发）：创建后端会话并同步所有端 */
   onNewChat?: () => void
   /** 重置连接（设置弹窗触发）：清除 token 回到配对页 */
   onDisconnect?: () => void

--- a/frontend/src/mobile/store.test.ts
+++ b/frontend/src/mobile/store.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { chatReducer, initialChatState, type ChatState } from './store'
+
+describe('mobile session_changed sync', () => {
+  it('clears the previous chat state while preserving mode and identity', () => {
+    const state: ChatState = {
+      ...initialChatState,
+      messages: [{ id: 'old', role: 'user', content: '旧会话' }],
+      activity: {
+        running: true,
+        goal: '旧任务',
+        mode: 'custom',
+        tools: [{ callId: 'call-1', name: 'Read' }],
+        paused: true,
+        pauseActionId: 'pause-1',
+        startedAt: 1,
+        pausedAt: 2,
+      },
+      pendingConfirm: {
+        actionId: 'security-1',
+        tool: 'Write',
+        params: '{}',
+        risk: 'high',
+        reason: 'test',
+      },
+      pendingUserInput: {
+        actionId: 'input-1',
+        title: '输入',
+        prompt: '请输入',
+        sensitive: false,
+        inputType: 'text',
+      },
+      refining: true,
+      identity: { assistantName: 'Nuphus', userLabel: '用户' },
+      tokenUsage: { inputTokens: 123 },
+      workflowRun: { steps: [], isPaused: true, done: false },
+    }
+
+    const next = chatReducer(state, {
+      type: 'event',
+      event: { type: 'session_changed', session_id: 'new-session', source: 'desktop' },
+    })
+
+    expect(next.messages).toEqual([])
+    expect(next.activity).toEqual({
+      running: false,
+      goal: '',
+      mode: 'custom',
+      tools: [],
+      paused: false,
+      pauseActionId: undefined,
+      startedAt: undefined,
+      pausedAt: undefined,
+    })
+    expect(next.pendingConfirm).toBeNull()
+    expect(next.pendingUserInput).toBeNull()
+    expect(next.refining).toBe(false)
+    expect(next.tokenUsage).toBeUndefined()
+    expect(next.workflowRun).toBeUndefined()
+    expect(next.identity).toEqual(state.identity)
+  })
+})

--- a/frontend/src/mobile/store.ts
+++ b/frontend/src/mobile/store.ts
@@ -606,6 +606,10 @@ function applyEvent(state: ChatState, ev: NuphusEvent): ChatState {
       if (!ev.model) return state
       return { ...state, model: ev.model }
 
+    case 'session_changed':
+      // 任意一端创建新会话：所有手机同步进入空白会话。
+      return chatReducer(state, { type: 'new_chat' })
+
     case 'token_usage': {
       // 会话累计上下文用量（input/output/cache_hit），驱动模型卡「上下文 xx%」与执行弹窗统计
       if (typeof ev.input_tokens !== 'number' || ev.input_tokens < 0) return state
@@ -721,14 +725,27 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       // 重拉历史（首载 / 断线重连补齐）：直接替换本地视图
       return { ...state, messages: action.messages }
     case 'new_chat':
-      // 新会话：清空前端消息与待处理卡片（历史仍在后端，刷新可恢复）
+      // 后端已创建新会话：清空本端视图与所有上一会话瞬态。
       return {
         ...state,
         messages: [],
+        activity: {
+          ...state.activity,
+          running: false,
+          goal: '',
+          tools: [],
+          paused: false,
+          pauseActionId: undefined,
+          startedAt: undefined,
+          pausedAt: undefined,
+        },
         pendingConfirm: null,
         pendingRefine: null,
         pendingUserInput: null,
+        refining: false,
+        tokenUsage: undefined,
         workflowRun: undefined,
+        workflowDismissed: undefined,
       }
     case 'history_merge': {
       // 执行中重连补历史：合并而非替换——保留本地仍在流式中的消息，

--- a/frontend/src/test/locales.test.ts
+++ b/frontend/src/test/locales.test.ts
@@ -21,7 +21,7 @@ describe('locales 中英键一致性', () => {
   })
 
   it('键数量记录（改动时此处数字应同步更新）', () => {
-    expect(Object.keys(zh).length).toBe(1074)
-    expect(Object.keys(en).length).toBe(1074)
+    expect(Object.keys(zh).length).toBe(1079)
+    expect(Object.keys(en).length).toBe(1079)
   })
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '/api': 'http://127.0.0.1:9090',
       // 移动端开发期代理 → mobile_server（P1，默认端口 18772）
       '/message': 'http://127.0.0.1:18772',
+      '/new-chat': 'http://127.0.0.1:18772',
       '/history': 'http://127.0.0.1:18772',
       '/health': 'http://127.0.0.1:18772',
       '/ws': {

--- a/src-tauri/src/commands/process/shelf.rs
+++ b/src-tauri/src/commands/process/shelf.rs
@@ -13,7 +13,9 @@
 //! 旧磁盘镜像（config_dir/nuphus/sessions/{id}.json）由 migrate_legacy_mirrors
 //! 幂等导入 SQLite 后保留不删（保守）。
 
+use crate::emitter::CompoundEmitter;
 use crate::state::AppState;
+use nuphus::agent::events::{EventEmitter, NuphusEvent};
 use nuphus::session::{MessageRole, Session};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -564,9 +566,8 @@ fn switch_session_inner(state: &AppState, id: String) -> Result<(), String> {
 }
 
 /// 新建对话：归档当前（有内容才占槽）→ 安装空白会话，返回新 id
-#[tauri::command]
-pub fn new_chat_session_cmd(state: State<'_, AppState>) -> Result<String, String> {
-    guard_switch(&state).map_err(|c| c.to_string())?;
+pub(crate) fn new_chat_session_inner(state: &AppState) -> Result<String, String> {
+    guard_switch(state).map_err(|c| c.to_string())?;
 
     let current_mode = state
         .current_mode
@@ -576,27 +577,55 @@ pub fn new_chat_session_cmd(state: State<'_, AppState>) -> Result<String, String
     let kind = normalize_mode(&current_mode);
 
     let mut ctx = state.runtime.lock().map_err(|e| e.to_string())?;
-    archive_active(&state, &mut ctx, kind);
+    archive_active(state, &mut ctx, kind);
 
     let fresh = Session::new();
     let new_id = fresh.id.clone();
     if let Some(slot) = active_session_mut(&mut ctx, kind) {
         *slot = fresh;
     } else {
-        // 无 agent 槽（重启/build 后新进程槽为空）：清空 backup 表示新会话并返回新 id。
-        // 前端 handleNewChat 已 resetTransientUI 清空本地气泡，get_chat_history 因
-        // backup 与 agent 均为空返回欢迎页——与新会话语义一致；下次发消息时
+        // 无 agent 槽（重启/build 后新进程槽为空）：下方清空 backup 表示新会话。
+        // get_chat_history 因 backup 与 agent 均为空返回欢迎页；下次发消息时
         // run_runtime_with_config 从空 backup 构建全新 session。
-        if let Ok(mut sb) = state.session.lock() {
-            sb.session_backup = None;
-            sb.last_message.clear();
-            sb.last_message_images.clear();
-        }
         tracing::info!("[Shelf] 无 agent 槽，新建对话 {new_id} ({kind})（backup 已清空）");
-        return Ok(new_id);
+    }
+    drop(ctx);
+
+    // 会话边界必须同步清理恢复快照与消息去重键。否则新会话第一条消息若恰好与
+    // 上一会话末条相同，会被 completion dedup 当成重复提交而静默丢弃。
+    if let Ok(mut sb) = state.session.lock() {
+        sb.session_backup = None;
+        sb.last_message.clear();
+        sb.last_send_id = None;
+        sb.last_message_images.clear();
     }
     tracing::info!("[Shelf] 新建对话 {new_id} ({kind})");
     Ok(new_id)
+}
+
+/// 新建会话并通过统一事件协议广播到桌面与所有已连接手机。
+/// 桌面 IPC 与手机 HTTP 入口共用，保证会话边界只有一个权威来源。
+pub(crate) fn new_chat_session_with_event<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: &AppState,
+    source: &str,
+) -> Result<String, String> {
+    let session_id = new_chat_session_inner(state)?;
+    let emitter = CompoundEmitter::new(app, state);
+    emitter.emit(NuphusEvent::SessionChanged {
+        session_id: session_id.clone(),
+        source: source.to_string(),
+    });
+    Ok(session_id)
+}
+
+/// 桌面 IPC 新建对话入口。
+#[tauri::command]
+pub fn new_chat_session_cmd(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    new_chat_session_with_event(app, state.inner(), "desktop")
 }
 
 /// 重命名：覆盖表 + 元数据行；对 active 会话立即生效（归档时沿用）

--- a/src-tauri/src/mobile_server.rs
+++ b/src-tauri/src/mobile_server.rs
@@ -1,6 +1,6 @@
 //! 移动端局域网 HTTP+WS server（axum，绑 0.0.0.0，默认关闭）
 //!
-//! 手机 = 同一会话的第二块屏：POST /message 走 P0 抽取的共享入口
+//! 手机 = 同一会话的第二块屏：POST /new-chat 切换共享会话边界，POST /message 走共享入口
 //! `commands::process::submit_user_message`（source="mobile"），与桌面共用
 //! 同一 leader_agent / busy 锁 / 去重逻辑；GET /ws 把 NuphusEvent 实时推给手机。
 //!
@@ -330,6 +330,42 @@ async fn get_history<R: tauri::Runtime>(
             Json(serde_json::json!({ "error": e })),
         )
             .into_response(),
+    }
+}
+
+/// POST /new-chat：归档当前会话并创建空白会话。
+/// 复用桌面 Session Shelf 的同一实现；成功后 SessionChanged 经 CompoundEmitter
+/// 同时广播到桌面端与所有手机端，使各端立即进入同一个空白会话。
+async fn post_new_chat<R: tauri::Runtime>(
+    State(ctx): State<MobileCtx<R>>,
+    headers: HeaderMap,
+    Query(query): Query<AuthQuery>,
+) -> Response {
+    if !token_valid(&headers, &query, &ctx.token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let state = ctx.app.state::<AppState>();
+    match crate::commands::process::shelf::new_chat_session_with_event(
+        ctx.app.clone(),
+        state.inner(),
+        "mobile",
+    ) {
+        Ok(session_id) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "created",
+                "session_id": session_id
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            let status = if e == "busy" || e == "append_pending" {
+                StatusCode::CONFLICT
+            } else {
+                StatusCode::BAD_REQUEST
+            };
+            (status, Json(serde_json::json!({ "error": e }))).into_response()
+        }
     }
 }
 
@@ -1784,6 +1820,7 @@ fn create_router<R: tauri::Runtime>(ctx: MobileCtx<R>) -> Router {
         .route("/model-config", get(get_model_config))
         .route("/switch-model", post(post_switch_model))
         .route("/switch-mode", post(post_switch_mode))
+        .route("/new-chat", post(post_new_chat))
         .route("/message", post(post_message))
         .route("/confirm", post(post_confirm))
         .route("/user-input", post(post_user_input))
@@ -2422,6 +2459,13 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(r.status(), 401);
+            // 新建会话同样必须鉴权
+            let r = client
+                .post(format!("{base}/new-chat"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(r.status(), 401);
             // WS 无 token → 握手被拒（非 101）
             let (_s, headers) = ws_client::connect(
                 base.trim_start_matches("http://127.0.0.1:")
@@ -2450,6 +2494,71 @@ mod tests {
             );
             // query token 渠道与 header 等效（正确 token 的 WS 升级在 ws_receives_events 验证）
             let _ = token;
+        });
+    }
+
+    #[test]
+    fn test_new_chat_clears_backend_session_and_broadcasts() {
+        tokio_test::block_on(async {
+            let (base, token, app) = spawn_test_server().await;
+            let port: u16 = base
+                .trim_start_matches("http://127.0.0.1:")
+                .parse()
+                .unwrap();
+
+            // 构造旧会话恢复态与去重键，验证新会话边界会完整清理。
+            let old_session = nuphus::session::Session::new();
+            let old_id = old_session.id.clone();
+            let state = app.state::<AppState>();
+            {
+                let mut session = state.session.lock().unwrap();
+                session.session_backup = Some(serde_json::to_string(&old_session).unwrap());
+                session.last_message = "旧会话末条消息".to_string();
+                session.last_send_id = Some("old-send-id".to_string());
+                session.last_message_images = vec!["data:image/png;base64,old".to_string()];
+            }
+
+            // 先建立 WS 并等就绪，消除订阅与 POST 之间的竞态。
+            let (mut ws, headers) = ws_client::connect(port, &format!("/ws?token={token}"))
+                .await
+                .unwrap();
+            assert!(headers.contains("101"));
+            let hello = tokio::time::timeout(std::time::Duration::from_secs(5), ws.read_text())
+                .await
+                .expect("5s 内应收到 WS 就绪帧")
+                .unwrap();
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&hello).unwrap()["type"],
+                "ws_connected"
+            );
+
+            let response = np_client()
+                .post(format!("{base}/new-chat"))
+                .header("X-Mobile-Token", &token)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 200);
+            let body: serde_json::Value = response.json().await.unwrap();
+            let new_id = body["session_id"].as_str().unwrap();
+            assert!(!new_id.is_empty());
+            assert_ne!(new_id, old_id);
+
+            let session = state.session.lock().unwrap();
+            assert!(session.session_backup.is_none());
+            assert!(session.last_message.is_empty());
+            assert!(session.last_send_id.is_none());
+            assert!(session.last_message_images.is_empty());
+            drop(session);
+
+            let text = tokio::time::timeout(std::time::Duration::from_secs(5), ws.read_text())
+                .await
+                .expect("5s 内应收到 session_changed")
+                .unwrap();
+            let event: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(event["type"], "session_changed");
+            assert_eq!(event["session_id"], new_id);
+            assert_eq!(event["source"], "mobile");
         });
     }
 

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -210,6 +210,10 @@ pub enum NuphusEvent {
         timestamp: u64,
     },
 
+    /// 当前活动会话已切换为一个全新会话。
+    /// source: "desktop" | "mobile"，供多端同步清空本地视图。
+    SessionChanged { session_id: String, source: String },
+
     /// 运行模式切换（空闲态 set_mode 时广播，手机端同步「当前模式」）
     ModeChanged { mode: String },
 


### PR DESCRIPTION
## 变更概述

修复手机端开启新对话后，电脑端仍停留在旧对话页面的问题。

此前手机端点击“新对话”只会清空手机端的界面状态，没有真正切换后端会话，因此电脑端无法感知变化。

本次修改：

- 新增经过身份验证的 `POST /new-chat` 接口
- 手机端开启新对话时重置后端共享会话
- 广播 `session_changed` 事件到其他已连接客户端
- 电脑端收到事件后切换并重新加载新会话
- 完整清理手机端的临时会话状态
- 添加手机端会话同步回归测试
- 添加中英文错误提示

## 关联 Issue

暂无关联 Issue。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 交互 / UI 改进
- [ ] 底层优化 / 加固
- [ ] 创新模式 / 新功能范式
- [ ] 文档更新
- [ ] 重构
- [ ] CI / 构建相关

## 测试

- [x] `npx tsc --noEmit` 通过
- [x] `npm test` 通过（3 个测试）
- [x] `npm run build` 通过
- [ ] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets`

Rust 相关检查暂未在本地执行，因为本机尚未安装 Rust/Cargo 工具链。

## 手动验证

1. 手机端和电脑端连接同一个 Nuphus 实例
2. 在手机端点击“新对话”
3. 确认手机端进入空白新对话
4. 确认电脑端同步切换到新对话页面